### PR TITLE
Fix CorpseCorrection drawing on bigger objects

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -86,20 +86,23 @@ void Tile::drawBottom(const Point& dest, LightView* lightView)
 
     // common items, reverse order
     int redrawPreviousTopW = 0, redrawPreviousTopH = 0;
+    bool stopDrawing = false;
     for (auto it = m_things.rbegin(); it != m_things.rend(); ++it) {
         const ThingPtr& thing = *it;
+        if (thing->isLyingCorpse()) {
+            redrawPreviousTopW = std::max<int>(thing->getWidth() - 1, redrawPreviousTopW);
+            redrawPreviousTopH = std::max<int>(thing->getHeight() - 1, redrawPreviousTopH);
+        }
         if (thing->isOnTop() || thing->isOnBottom() || thing->isGroundBorder() || thing->isGround() || thing->isCreature())
-            break;
+            stopDrawing = true;
+
+        if (stopDrawing)
+            continue;
         if (thing->isHidden())
             continue;
 
         thing->draw(dest - m_drawElevation * g_sprites.getOffsetFactor() , true, lightView);
         m_drawElevation = std::min<uint8_t>(m_drawElevation + thing->getElevation(), Otc::MAX_ELEVATION);
-
-        if (thing->isLyingCorpse()) {
-            redrawPreviousTopW = std::max<int>(thing->getWidth() - 1, redrawPreviousTopW);
-            redrawPreviousTopH = std::max<int>(thing->getHeight() - 1, redrawPreviousTopH);
-        }
     }
 
     if (!g_game.getFeature(Otc::GameMapIgnoreCorpseCorrection)) {


### PR DESCRIPTION
Before:
![Screenshot from 2024-11-05 01-06-20](https://github.com/user-attachments/assets/71ba4d2b-bc1d-4aa8-83bd-70cd1e0b8016)
After:
![Screenshot from 2024-11-05 01-04-36](https://github.com/user-attachments/assets/cabb90d4-45cb-4ef6-b318-eeb6741239bc)

Iterate over **all** items on the tile to trigger corpse correction mechanism