### PR TITLE
Display big items in UI more conviniently

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -563,16 +563,19 @@ DrawQueueItem* ThingType::draw(const Rect& dest, int layer, int xPattern, int yP
     if (!size.isValid())
         return nullptr;
 
-    // size correction for some too big items
-    if ((m_size.width() > 1 || m_size.height() > 1) &&
-        textureRect.width() <= g_sprites.spriteSize() && textureRect.height() <= g_sprites.spriteSize()) {
-        size = Size(g_sprites.spriteSize(), g_sprites.spriteSize());
-        textureOffset = Point((g_sprites.spriteSize() - textureRect.width()) / m_size.width(),
-                              (g_sprites.spriteSize() - textureRect.height()) / m_size.height());
+    float scaleX = (float)dest.width() / size.width();
+    float scaleY = (float)dest.height() / size.height();
+    Size finalDrawSize = textureRect.size();
+    if (scaleX < 1) {
+        textureOffset.x = 0;
+        finalDrawSize.setWidth(dest.width());
+    }
+    if (scaleY < 1) {
+        textureOffset.y = 0;
+        finalDrawSize.setHeight(dest.height());
     }
 
-    float scale = std::min<float>((float)dest.width() / size.width(), (float)dest.height() / size.height());
-    return g_drawQueue->addTexturedRect(Rect(dest.topLeft() + (textureOffset * scale), textureRect.size() * scale), texture, textureRect, color);
+    return g_drawQueue->addTexturedRect(Rect(dest.topLeft() + textureOffset, finalDrawSize), texture, textureRect, color);
 }
 
 std::shared_ptr<DrawOutfitParams> ThingType::drawOutfit(const Point& dest, int maskLayer, int xPattern, int yPattern, int zPattern, int animationPhase, Color color, LightView* lightView)


### PR DESCRIPTION
Before:
![Screenshot from 2024-11-04 23-13-40](https://github.com/user-attachments/assets/a5cbdee4-1782-449e-9fc8-f9ebff03ea7e)
After:
![Screenshot from 2024-11-04 23-12-23](https://github.com/user-attachments/assets/f85077f0-9188-4834-b0f6-1a1d13a6190e)
Wand of decay corner case (still better than it was):
[backpack_show.webm](https://github.com/user-attachments/assets/457cecb1-508d-4ac9-a834-deb3f6768932)

