### PR TITLE
Disable follow displaying on target cancel

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -527,8 +527,10 @@ void Game::processModalDialog(uint32 id, std::string title, std::string message,
 
 void Game::processAttackCancel(uint seq)
 {
-    if(seq == 0 || m_seq == seq)
+    if(seq == 0 || m_seq == seq) {
         cancelAttack();
+        cancelFollow();
+    }
 }
 
 void Game::processWalkCancel(Otc::Direction direction)


### PR DESCRIPTION
When followed creature disappeared from screen (went away on the same floor or just changed floors), client kept displaying follow green frame.

Before:
[Screencast from 07.11.2024 12:17:48.webm](https://github.com/user-attachments/assets/71179425-fbec-44a3-8a29-065306e6dfca)

After:
[Screencast from 07.11.2024 12:16:48.webm](https://github.com/user-attachments/assets/990eb61a-d403-4770-b9d8-a4576ad9fab6)
