### PR TITLE
Use separate minimap temporary files per process when saving

### DIFF
--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -37,6 +37,8 @@
 
 #include <framework/util/stats.h>
 
+#include <unistd.h>
+
 Minimap g_minimap;
 
 void MinimapBlock::clean()
@@ -383,6 +385,7 @@ void Minimap::saveOtmm(const std::string& fileName)
 
 #ifndef ANDROID
         std::string tmpFileName = fileName;
+        tmpFileName += "." + std::to_string(getpid());
         tmpFileName += ".tmp";
         FileStreamPtr fin = g_resources.createFile(tmpFileName);
 #else


### PR DESCRIPTION
When there are two clients running, closing both of them at the same time can result in map loss on disk.
(both write to the same temporary file?). Solve that by using separate tmp files per PID. I assume any race on `rename` is not possible due to OS-specific mechanisms.