### PR TITLE
Display Item Duration feature

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -225,6 +225,7 @@ GameMissionId = 125
 GameItemCustomAttributes = 126
 GameAnimatedTextCustomFont = 127
 GameDrawFloorShadow = 128
+GameDisplayItemDuration = 129
 
 LastGameFeature = 130
         

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -489,6 +489,7 @@ namespace Otc
         GameItemCustomAttributes = 126,
         GameAnimatedTextCustomFont = 127,
         GameDrawFloorShadow = 128,
+        GameDisplayItemDuration = 129,
 
         LastGameFeature = 130
     };

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -47,7 +47,10 @@ Item::Item() :
     m_async(true),
     m_quickLootFlags(0),
     m_phase(0),
-    m_lastPhase(0)
+    m_lastPhase(0),
+    m_durationTime(0),
+    m_durationTimePaused(0),
+    m_durationIsPaused(false)
 {
     m_animator = std::make_shared<Animator>();
     m_idleAnimator = std::make_shared<Animator>();

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -94,6 +94,13 @@ public:
     void setTooltip(const std::string& str) { m_tooltip = str; }
     void setQuickLootFlags(uint32 flags) { m_quickLootFlags = flags; }
     void setShader(const std::string& str) { m_shader = str; }
+    void setDurationTime(uint64 value) { m_durationTime = value; }
+    void setDurationIsPaused(bool value) {
+        m_durationIsPaused = value;
+        if (m_durationIsPaused) {
+            m_durationTimePaused = stdext::unixtimeMs();
+        }
+    }
 
     int getCountOrSubType() { return m_countOrSubType; }
     int getSubType();
@@ -106,6 +113,9 @@ public:
     std::string getTooltip() { return m_tooltip; }
     uint32 getQuickLootFlags() { return m_quickLootFlags; }
     std::string getShader() { return m_shader; }
+    uint64 getDurationTime() { return m_durationTime; }
+    uint64 getDurationTimePaused() { return m_durationTimePaused; }
+    bool isDurationPaused() const { return m_durationIsPaused; }
 
     void unserializeItem(const BinaryTreePtr& in);
     void serializeItem(const OutputBinaryTreePtr& out);
@@ -184,6 +194,10 @@ private:
     uint32 m_quickLootFlags;
     uint8 m_phase;
     ticks_t m_lastPhase;
+
+    uint64 m_durationTime;
+    uint64 m_durationTimePaused;
+    bool m_durationIsPaused;
 
     stdext::packed_storage<uint16> m_customAttribs;
 };

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3628,6 +3628,16 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id, bool hasDescri
         }
     }
 
+    if (g_game.getFeature(Otc::GameDisplayItemDuration)) {
+        uint8_t hasDuration = msg->getU8();
+        if (hasDuration) {
+            uint64_t duration = msg->getU64();
+            bool stopTime = msg->getU8() == 1;
+            item->setDurationTime(duration);
+            item->setDurationIsPaused(stopTime);
+        }
+    }
+
     return item;
 }
 

--- a/src/client/uiitem.h
+++ b/src/client/uiitem.h
@@ -66,6 +66,11 @@ protected:
     stdext::boolean<false> m_showCountAlways;
     std::string m_shader;
     std::string m_countText;
+
+    ticks_t m_lastDecayUpdate;
+    std::string m_decayText;
+    Color m_decayColor;
+    Color m_decayPausedColor;
 };
 
 #endif

--- a/src/framework/stdext/string.cpp
+++ b/src/framework/stdext/string.cpp
@@ -298,4 +298,21 @@ std::vector<std::string> split(const std::string& str, const std::string& separa
     return splitted;
 }
 
+std::string secondsToDuration(uint32 totalSeconds) {
+    int days = totalSeconds / 86400;
+    int hours = (totalSeconds % 86400) / 3600;
+    int minutes = (totalSeconds % 3600) / 60;
+    int seconds = totalSeconds % 60;
+    if (days > 0) {
+        return format("%dd", days);
+    }
+    else if (hours > 0) {
+        return format("%0dh", hours);
+    }
+    else if (minutes > 0) {
+        return format("%dm", minutes);
+    }
+    return format("%ds", seconds);
+}
+
 }

--- a/src/framework/stdext/string.h
+++ b/src/framework/stdext/string.h
@@ -74,6 +74,8 @@ template<typename T> std::vector<T> split(const std::string& str, const std::str
     return results;
 }
 
+std::string secondsToDuration(uint32 totalSeconds);
+
 }
 
 #endif

--- a/src/framework/stdext/time.cpp
+++ b/src/framework/stdext/time.cpp
@@ -45,11 +45,16 @@ ticks_t micros() {
 void millisleep(size_t ms)
 {
     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
-};
+}
 
 void microsleep(size_t us)
 {
     std::this_thread::sleep_for(std::chrono::microseconds(us));
-};
+}
+
+ticks_t unixtimeMs()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
 
 }

--- a/src/framework/stdext/time.h
+++ b/src/framework/stdext/time.h
@@ -32,6 +32,7 @@ ticks_t millis();
 ticks_t micros();
 void millisleep(size_t ms);
 void microsleep(size_t us);
+ticks_t unixtimeMs();
 
 struct timer {
 public:


### PR DESCRIPTION
Displays duration (`Xd` for days, `Xh` for hours, `Xm` for minutes, `Xs` for seconds) left on an item with decay.
Requires server side changes and better decay system than the one from TFS for ideal precision.
I have created 1 commit change for TFS 1.4.2 with new decay system and code for this new feature, you can check it here: https://github.com/Oen44/tfs-new-decay/commit/f72bde7c08a580c93336d33cbf857b1a008a2764
![otclient_gl_BGP0ApDRFK](https://github.com/user-attachments/assets/a60d703f-9c99-4bb8-9e5c-e42cfb99f709)
