### PR TITLE
Compile issues in linux, missing `<sting>` import

### DIFF
--- a/src/framework/util/stats.h
+++ b/src/framework/util/stats.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <mutex>
 #include <chrono>
+#include <string>
 #include <unordered_map>
 #include <set>
 


### PR DESCRIPTION
- Fixes compile issue on linux