### PR TITLE
Fix hotkeys not repeating on Windows

### DIFF
--- a/modules/corelib/keybind.lua
+++ b/modules/corelib/keybind.lua
@@ -943,9 +943,9 @@ function Keybind.bindHotkey(hotkeyId, chatMode)
     keys.primary = tostring(keys.primary)
     if keys.primary:len() > 0 then
       if action == HOTKEY_ACTION.EQUIP or action == HOTKEY_ACTION.USE or action == HOTKEY_ACTION.TEXT or action == HOTKEY_ACTION.TEXT_AUTO then
-        g_keyboard.bindKeyDown(keys.primary, hotkey.callback, gameRootPanel)
-      else
         g_keyboard.bindKeyPress(keys.primary, hotkey.callback, gameRootPanel)
+      else
+        g_keyboard.bindKeyDown(keys.primary, hotkey.callback, gameRootPanel)
       end
     end
   end
@@ -954,9 +954,9 @@ function Keybind.bindHotkey(hotkeyId, chatMode)
     keys.secondary = tostring(keys.secondary)
     if keys.secondary:len() > 0 then
       if action == HOTKEY_ACTION.EQUIP or action == HOTKEY_ACTION.USE or action == HOTKEY_ACTION.TEXT or action == HOTKEY_ACTION.TEXT_AUTO then
-        g_keyboard.bindKeyDown(keys.secondary, hotkey.callback, gameRootPanel)
-      else
         g_keyboard.bindKeyPress(keys.secondary, hotkey.callback, gameRootPanel)
+      else
+        g_keyboard.bindKeyDown(keys.secondary, hotkey.callback, gameRootPanel)
       end
     end
   end


### PR DESCRIPTION
These calls appeared to be swapped, which caused hotkeys to not properly repeat on Windows. On Linux it didn't matter, both versions worked.