### PR TITLE
Change "(size_t)" to "static_cast<size_t>"

### DIFF
--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -68,7 +68,7 @@ void Container::onAddItem(const ItemPtr& item, int slot)
 
     if(slot == 0)
         m_items.push_front(item);
-    else if (slot > 0 && m_items.size() <= (size_t)(m_capacity - 1))
+    else if (slot > 0 && m_items.size() <= static_cast<size_t>(m_capacity - 1))
         m_items.push_back(item);
     updateItemsPositions();
 


### PR DESCRIPTION
This modification is necessary to maintain the standard already used.

@Oen44 