### PR TITLE
Fix actionbar widget callbacks firing multiple times at once

### DIFF
--- a/modules/client_options/controls.otui
+++ b/modules/client_options/controls.otui
@@ -33,6 +33,18 @@ OptionPanel
     maximum: 1000
 
   Label
+    id: actionbarWidgetDelayLabel
+    !tooltip: tr('Time between execution of the same actionbar widget')
+    @onSetup: |
+      local value = modules.client_options.getOption('actionbarWidgetDelay')
+      self:setText(tr('Actionbar widget delay: %s ms', value))
+
+  OptionScrollbar
+    id: actionbarWidgetDelay
+    minimum: 5
+    maximum: 1000
+
+  Label
     id: walkFirstStepDelayLabel
     @onSetup: |
       local value = modules.client_options.getOption('walkFirstStepDelay')

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -42,6 +42,7 @@ local defaultOptions = {
   dontStretchShrink = false,
   turnDelay = 30,
   hotkeyDelay = 200,
+  actionbarWidgetDelay = 200,
 
   chatMode = CHAT_MODE.ON,
   walkFirstStepDelay = 200,
@@ -638,6 +639,8 @@ function updateValues(key, value)
     end
   elseif key == "hotkeyDelay" then
     controlsPanel:getChildById("hotkeyDelayLabel"):setText(tr("Hotkey delay: %s ms", value))
+  elseif key == "actionbarWidgetDelay" then
+    controlsPanel:getChildById("actionbarWidgetDelayLabel"):setText(tr("Actionbar widget delay: %s ms", value))
   elseif key == "walkFirstStepDelay" then
     controlsPanel:getChildById("walkFirstStepDelayLabel"):setText(tr("Walk delay after first step: %s ms", value))
   elseif key == "walkTurnDelay" then

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -372,6 +372,7 @@ function setupButton(widget)
   widget.text:setImageSource('')
   widget.hotkey = config and config.hotkey or ""
   widget.callback = nil
+  widget.lastExecution = 0
 
   -- add new settings
   if config and config.type then
@@ -967,12 +968,20 @@ function assignHotkey(widget)
   end
 end
 
+function checkLastExecution(widget)
+  widget.lastExecution = widget.lastExecution or 0
+  return widget.lastExecution + g_settings.getNumber("actionbarWidgetDelay") < g_clock.millis()
+end
+
 function setupAction(widget)
   if widget.type == TYPE.BLANK then 
     return
   end
   if widget.type == TYPE.TEXT then
     widget.callback = function()
+      if not checkLastExecution(widget) then return end
+      widget.lastExecution = g_clock.millis()
+
       if modules.game_interface.isChatVisible() then
         if widget.autoSay then
           modules.game_console.sendMessage(widget.sayText)
@@ -985,6 +994,9 @@ function setupAction(widget)
     end
   elseif widget.type == TYPE.SPELL then
     widget.callback = function()
+      if not checkLastExecution(widget) then return end
+      widget.lastExecution = g_clock.millis()
+
       if g_app.isMobile() then -- turn to direction of targer
         local target = g_game.getAttackingCreature()
         if target then
@@ -1015,6 +1027,9 @@ function setupAction(widget)
     end
   elseif widget.type == TYPE.ITEM then
     widget.callback = function()
+      if not checkLastExecution(widget) then return end
+      widget.lastExecution = g_clock.millis()
+
       if widget.action == ACTION.BLANK then
         return
       elseif widget.action == ACTION.EQUIP then


### PR DESCRIPTION
Fix actionbar widget callbacks firing multiple times at once by adding a delay between callback executions;
Add actionbarWidgetDelay to client_options.