### PR TITLE
Fix "g_game.cancelAttack()"

### DIFF
--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -68,7 +68,7 @@ void Container::onAddItem(const ItemPtr& item, int slot)
 
     if(slot == 0)
         m_items.push_front(item);
-    else if (slot > 0 && m_items.size() <= (size_t)(m_capacity - 1))
+    else if (slot > 0 && m_items.size() <= static_cast<int>(m_capacity - 1))
         m_items.push_back(item);
     updateItemsPositions();
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -528,7 +528,9 @@ void Game::processModalDialog(uint32 id, std::string title, std::string message,
 void Game::processAttackCancel(uint seq)
 {
     if(seq == 0 || m_seq == seq) {
-        cancelAttack();
+        if (isAttacking()) {
+            cancelAttack();
+        }
         cancelFollow();
     }
 }
@@ -955,7 +957,7 @@ void Game::refreshContainer(const ContainerPtr& container)
     m_protocolGame->sendRefreshContainer(container->getId());
 }
 
-void Game::attack(CreaturePtr creature, bool cancel)
+void Game::attack(CreaturePtr creature)
 {
     if(!canPerformGameAction() || creature == m_localPlayer)
         return;
@@ -976,8 +978,7 @@ void Game::attack(CreaturePtr creature, bool cancel)
     } else
         m_seq++;
 
-    if(!cancel)
-        m_protocolGame->sendAttack(creature ? creature->getId() : 0, m_seq);
+    m_protocolGame->sendAttack(creature ? creature->getId() : 0, m_seq);
 }
 
 void Game::follow(CreaturePtr creature)

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -201,8 +201,8 @@ public:
     void refreshContainer(const ContainerPtr& container);
 
     // attack/follow related
-    void attack(CreaturePtr creature, bool cancel = false);
-    void cancelAttack() { attack(nullptr, true); }
+    void attack(CreaturePtr creature);
+    void cancelAttack() { attack(nullptr); }
     void follow(CreaturePtr creature);
     void cancelFollow() { follow(nullptr); }
     void cancelAttackAndFollow();


### PR DESCRIPTION
Before this fix, the target cancellation was not being sent to the Server (so it was only being cancelled by the client and not by the Server)

The byte must ALWAYS be sent to the Server, and the Server recognizes this byte in the following way:

when id = 0: cancel the target

when id > 0: the Server checks if the creature exists and applies the target to it