### PR TITLE
Fix canceling attack target (#56)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -527,9 +527,8 @@ void Game::processModalDialog(uint32 id, std::string title, std::string message,
 
 void Game::processAttackCancel(uint seq)
 {
-    if(seq == 0 || m_seq == seq) {
+    if(isAttacking() && (seq == 0 || m_seq == seq)) {
         cancelAttack();
-        cancelFollow();
     }
 }
 
@@ -955,7 +954,7 @@ void Game::refreshContainer(const ContainerPtr& container)
     m_protocolGame->sendRefreshContainer(container->getId());
 }
 
-void Game::attack(CreaturePtr creature, bool cancel)
+void Game::attack(CreaturePtr creature)
 {
     if(!canPerformGameAction() || creature == m_localPlayer)
         return;
@@ -976,8 +975,7 @@ void Game::attack(CreaturePtr creature, bool cancel)
     } else
         m_seq++;
 
-    if(!cancel)
-        m_protocolGame->sendAttack(creature ? creature->getId() : 0, m_seq);
+    m_protocolGame->sendAttack(creature ? creature->getId() : 0, m_seq);
 }
 
 void Game::follow(CreaturePtr creature)

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -201,8 +201,8 @@ public:
     void refreshContainer(const ContainerPtr& container);
 
     // attack/follow related
-    void attack(CreaturePtr creature, bool cancel = false);
-    void cancelAttack() { attack(nullptr, true); }
+    void attack(CreaturePtr creature);
+    void cancelAttack() { attack(nullptr); }
     void follow(CreaturePtr creature);
     void cancelFollow() { follow(nullptr); }
     void cancelAttackAndFollow();


### PR DESCRIPTION
In the last commit, it is necessary to remove the action "cancelFollow();" from the "processAttackCancel" function.

How it currently works:

- The player is attacking a creature
- He follows another creature
- The attack is removed but the follow is not maintained

How it should work:

- The player is attacking a creature
- He follows another creature
- The attack is removed and the follow is added and maintained