### PR TITLE
Fix follow when alrady having target

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -527,11 +527,8 @@ void Game::processModalDialog(uint32 id, std::string title, std::string message,
 
 void Game::processAttackCancel(uint seq)
 {
-    if(seq == 0 || m_seq == seq) {
-        if (isAttacking()) {
-            cancelAttack();
-        }
-        cancelFollow();
+    if(isAttacking() && (seq == 0 || m_seq == seq)) {
+        cancelAttack();
     }
 }
 


### PR DESCRIPTION
How it currently works:

- The player is attacking a creature
- He follows another creature
- The attack is removed but the follow is not maintained How it should work:

How it should be:

- The player is attacking a creature
- He follows another creature
- The attack is removed and the follow is added and maintained