### PR TITLE
Validate minimap on possible crash / using MC

### DIFF
--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -30,7 +30,8 @@
 enum {
     MMBLOCK_SIZE = 64,
     OTMM_SIGNATURE = 0x4D4d544F,
-    OTMM_VERSION = 1
+    OTMM_VERSION = 1,
+    OTMM_VALID = 0x444F4E45
 };
 
 enum MinimapTileFlags {


### PR DESCRIPTION
Use same method of creating temp files for pc clients similar to android. 

- Adding marker to verify if the temp file has completed generation of minimap to file.
- Checks if the temp minimap is larger than the previous minimap.
- Added exception for not finding the VALID marker. 
- Added an additional handler to throw error if theres an unexpected error. 


Resolves: 
- Multi Client minimap wipes. 
- Minimap wipe on client crash

