### PR TITLE
New OTUI nodes

### DIFF
--- a/src/framework/ui/uimanager.h
+++ b/src/framework/ui/uimanager.h
@@ -49,6 +49,7 @@ public:
     bool importStyle(std::string file);
     bool importStyleFromString(std::string data);
     void importStyleFromOTML(const OTMLNodePtr& styleNode);
+    void mergeStyle(std::string file, const UIWidgetPtr& widget);
     OTMLNodePtr getStyle(const std::string& styleName);
     std::string getStyleClass(const std::string& styleName);
 

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -1563,6 +1563,10 @@ void UIWidget::onStyleApply(const std::string& styleName, const OTMLNodePtr& sty
     parseBaseStyle(styleNode);
     parseImageStyle(styleNode);
     parseTextStyle(styleNode);
+
+    // lastly merge with another otui
+    if (const OTMLNodePtr& node = styleNode->get("merge-otui"))
+        g_ui.mergeStyle(stdext::resolve_path(node->value(), node->source()), static_self_cast<UIWidget>());
 }
 
 void UIWidget::onGeometryChange(const Rect& oldRect, const Rect& newRect)

--- a/src/framework/ui/uiwidgetbasestyle.cpp
+++ b/src/framework/ui/uiwidgetbasestyle.cpp
@@ -370,6 +370,9 @@ void UIWidget::parseBaseStyle(const OTMLNodePtr& styleNode)
                 }
             }
         }
+        else if (node->tag() == "load-otui") {
+            g_ui.loadUI(stdext::resolve_path(node->value(), node->source()), static_self_cast<UIWidget>());
+        }
     }
 }
 


### PR DESCRIPTION
- `load-otui: <path>` will load otui file from path and add as child widget, equivalent to `g_ui.loadUI(path, self)`
Example:
```
MainWindow
  Panel
    id: header
    load-otui: header
  Panel
    id: body
    load-otui: body
  Panel
    id: footer
    load-otui: footer
```
- `merge-otui: <path>` will load otui file from path and merge it with currently applied style
Example:
```
MainWindow
  Panel
    merge-otui: header
  Panel
    merge-otui: body
  Panel
    merge-otui: footer
```