### PR TITLE
feat: Map and Minimap saveImage functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ ipch/
 # ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper
+
+# JetBrain tools
+/.idea

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -129,6 +129,17 @@ void Item::draw(const Rect& dest, bool animate)
     }
 }
 
+bool Item::drawToImage(const Point& dest, ImagePtr image)
+{
+    if (m_clientId == 0)
+        return false;
+
+    int xPattern = 0, yPattern = 0, zPattern = 0;
+    calculatePatterns(xPattern, yPattern, zPattern);
+
+    return rawGetThingType()->drawToImage(dest, xPattern, yPattern, zPattern, image);
+}
+
 void Item::setId(uint32 id)
 {
     if(!g_things.isValidDatId(id, ThingCategoryItem))

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -84,6 +84,7 @@ public:
 
     void draw(const Point& dest, bool animate = true, LightView* lightView = nullptr);
     void draw(const Rect& dest, bool animate = true);
+    bool drawToImage(const Point& dest, ImagePtr image);
 
     void setId(uint32 id);
     void setOtbId(uint16 id);

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -175,6 +175,9 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_map", "isWalkable", &Map::isWalkable, &g_map);
     g_lua.bindSingletonFunction("g_map", "checkSightLine", &Map::checkSightLine, &g_map);
     g_lua.bindSingletonFunction("g_map", "isSightClear", &Map::isSightClear, &g_map);
+    g_lua.bindSingletonFunction("g_map", "saveImage", &Map::saveImage, &g_map);
+    g_lua.bindSingletonFunction("g_map", "getLowerFloorsShadowPercent", &Map::getLowerFloorsShadowPercent, &g_map);
+    g_lua.bindSingletonFunction("g_map", "setLowerFloorsShadowPercent", &Map::setLowerFloorsShadowPercent, &g_map);
 
     g_lua.registerSingletonClass("g_minimap");
     g_lua.bindSingletonFunction("g_minimap", "clean", &Minimap::clean, &g_minimap);

--- a/src/client/map.h
+++ b/src/client/map.h
@@ -173,6 +173,10 @@ public:
     void loadOtbm(const std::string& fileName);
     void saveOtbm(const std::string& fileName);
 
+    void saveImage(const std::string& fileName, int minX, int minY, int maxX, int maxY, short z, bool drawLowerFloors);
+    uint8 getLowerFloorsShadowPercent() { return lowerFloorsShadowPercent; }
+    void setLowerFloorsShadowPercent(uint8 newLowerFloorsShadowPercent) { lowerFloorsShadowPercent = newLowerFloorsShadowPercent; }
+
     // otbm attributes (description, size, etc.)
     void setHouseFile(const std::string& file) { m_attribs.set(OTBM_ATTR_HOUSE_FILE, file); }
     void setSpawnFile(const std::string& file) { m_attribs.set(OTBM_ATTR_SPAWN_FILE, file); }
@@ -300,6 +304,9 @@ private:
     stdext::packed_storage<uint8> m_attribs;
     AwareRange m_awareRange;
     static TilePtr m_nulltile;
+
+    // only for map PNG image generator
+    uint8 lowerFloorsShadowPercent = 0;
 };
 
 extern Map g_map;

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -310,9 +310,24 @@ bool Minimap::loadImage(const std::string& fileName, const Position& topLeft, fl
     }
 }
 
-void Minimap::saveImage(const std::string& fileName, const Rect& mapRect)
+void Minimap::saveImage(const std::string& fileName, int minX, int minY, int maxX, int maxY, short z)
 {
-    //TODO
+   ImagePtr image(new Image(Size(maxX - minX, maxY - minY)));
+
+   for (int x = minX; x < maxX; x++) {
+           for (int y = minY; y < maxY; y++) {
+                   uint8 c = getTile(Position(x, y, z)).color;
+                   Color col = Color::alpha;
+                   if(c != 255) {
+                           col = Color::from8bit(c);
+                   }
+                   col.setAlpha(255);
+                   image->setPixel(x - minX, y - minY, col);
+
+           }
+   }
+
+   image->savePNG(fileName);
 }
 
 bool Minimap::loadOtmm(const std::string& fileName)
@@ -447,6 +462,19 @@ void Minimap::saveOtmm(const std::string& fileName)
         if(std::filesystem::file_size(tmpFilePath) > 1024) {
             std::filesystem::rename(tmpFilePath, filePath);
         }
+/*
+        std::stringstream path;
+        path << "exported_minimaps/"<< fileName;
+        std::ofstream outfile(path.str(), std::ofstream::binary);
+        if (!outfile.is_open() || !outfile.good()) {
+            g_logger.error(stdext::format("Unable to save minimap to '%s'", path.str()));
+            return;
+        }
+
+        std::string data = g_resources.readFileContents(fileName);
+        outfile.write(data.c_str(), data.length());
+        outfile.close();
+*/
 #endif
     } catch (stdext::exception& e) {
         g_logger.error(stdext::format("failed to save OTMM minimap: %s", e.what()));

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -97,7 +97,7 @@ public:
     std::pair<MinimapBlock_ptr, MinimapTile> threadGetTile(const Position& pos);
 
     bool loadImage(const std::string& fileName, const Position& topLeft, float colorFactor);
-    void saveImage(const std::string& fileName, const Rect& mapRect);
+    void saveImage(const std::string& fileName, int minX, int minY, int maxX, int maxY, short z);
     bool loadOtmm(const std::string& fileName);
     void saveOtmm(const std::string& fileName);
 

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -38,6 +38,7 @@ public:
     virtual ~Thing();
 
     virtual void draw(const Point& dest, bool animate = true, LightView* lightView = nullptr) { }
+    virtual bool drawToImage(const Point& dest, ImagePtr image) { return false; }
 
     virtual void setId(uint32 id) { }
     void setPosition(const Position& position);

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -713,6 +713,35 @@ void ThingType::drawWithShader(const Rect& dest, int layer, int xPattern, int yP
     //return g_drawQueue->addTexturedRect(Rect(dest.topLeft() + (textureOffset * scale), textureRect.size() * scale), texture, textureRect, color);
 }
 
+bool ThingType::drawToImage(const Point& dest, int xPattern, int yPattern, int zPattern, ImagePtr image)
+{
+    if (m_null)
+        return false;
+
+    bool anythingDrawn = false;
+    int spriteSize = g_sprites.spriteSize();
+
+    for (int l = 0; l < m_layers; ++l) {
+        for (int w = 0; w < m_size.width(); ++w)
+        {
+            int x = dest.x;
+            for (int h = 0; h < m_size.height(); ++h)
+            {
+                int y = dest.y;
+                int dx = x + spriteSize * (m_size.width() - w - 1) - spriteSize * (m_size.width() - 1);
+                int dy = y + spriteSize * (m_size.height() - h - 1) - spriteSize * (m_size.height() - 1);
+                if (dx >= 0 && dy >= 0)
+                {
+                    anythingDrawn = true;
+                    image->blit(Point(dx, dy), g_sprites.getSpriteImage(m_spritesIndex[getSpriteIndex(w, h, l, xPattern, yPattern, zPattern, 0)]));
+                }
+            }
+        }
+    }
+
+    return anythingDrawn;
+}
+
 const TexturePtr& ThingType::getTexture(int animationPhase)
 {
     m_lastUsage = g_clock.seconds();

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -185,6 +185,7 @@ public:
     Rect getDrawSize(const Point& dest, int layer, int xPattern, int yPattern, int zPattern, int animationPhase);
     void drawWithShader(const Point& dest, int layer, int xPattern, int yPattern, int zPattern, int animationPhase, const std::string& shader, Color color = Color::white, LightView* lightView = nullptr);
     void drawWithShader(const Rect& dest, int layer, int xPattern, int yPattern, int zPattern, int animationPhase, const std::string& shader, Color color = Color::white);
+    bool drawToImage(const Point& dest, int xPattern, int yPattern, int zPattern, ImagePtr image);
 
     uint16 getId() { return m_id; }
     ThingCategory getCategory() { return m_category; }

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -71,6 +71,7 @@ public:
     void drawTop(const Point& dest, LightView* lightView = nullptr);
     void drawTexts(Point dest);
     void drawWidget(Point dest);
+    bool drawToImage(const Point& dest, ImagePtr image);
 
 public:
     void clean();

--- a/src/framework/graphics/image.h
+++ b/src/framework/graphics/image.h
@@ -42,6 +42,9 @@ public:
     ImagePtr upscale();
     void resize(const Size& size) { m_size = size; m_pixels.resize(size.area() * m_bpp, 0); }
     bool nextMipmap();
+    void cutBottomRight(int widthCut, int heightCut);
+    void addShadowToSquare(const Point& dest, int squareSize, uint8 orginalPercent);
+    void addShadow(uint8 orginalPercent);
 
     void setPixel(int x, int y, uint8 *pixel) { memcpy(&m_pixels[(y * m_size.width() + x) * m_bpp], pixel, m_bpp);}
     void setPixel(int x, int y, uint32_t argb) { setPixel(x, y, (uint8*)&argb); }


### PR DESCRIPTION
## This PR adds 2 new functions
```lua
g_minimap.saveImage(std::string fileName, int minX, int minY, int maxX, int maxY, short z)
g_map.saveImage(std::string fileName, int minX, int minY, int maxX, int maxY, short z, bool drawLowerFloors)
```
`g_minimap.saveImage` existed before, but had empty body and other parameters.

`g_minimap.saveImage` - saves minimap as PNG image.
`g_map.saveImage` - saves view like in OTC as PNG image.

## How to use

In example I use TFS 1.4 server and Tibia Client 10.98 files.

### Prepare client
1. Put client `Tibia.dat`, `Tibia.spr` and server `items.otb` and map `.otbm` file in `data` directory.
2. In 'Enter Game' window pick client version you want to use and try to login (any IP/login/password, it can fail) - it fixes OTCv8 bug related to `g_game.setClientVersion` function.
3. Open OTC terminal: press CTRL+T.
4. Type this to load client and server files:
```lua
g_game.setClientVersion(1098)
g_things.loadOtb('things/1098/items.otb')
g_map.loadOtbm('things/1098/forgotten.otbm')
```
you can also paste it as 1 line:
```lua
g_game.setClientVersion(1098) g_things.loadOtb('things/1098/items.otb') g_map.loadOtbm('things/1098/forgotten.otbm')
```
If it shows some errors or crash client, you must enable your custom OTC features or you missed step 2.

### Generate images

**Minimap image from 0,0 to 500,500 on floor 7:**
```lua
g_minimap.saveImage('test_minimap.png', 0, 0, 500, 500, 7)
```
<img width="500" height="500" alt="test_minimap" src="https://github.com/user-attachments/assets/cd9e275f-df28-4695-b497-e7f04eb107c1" />

**Map image from 140,380 to 170,400 floor 7:**
```lua
g_map.saveImage('test_map_7.png', 140, 380, 170, 400, 7, false)
```
<img width="960" height="640" alt="test_map_7" src="https://github.com/user-attachments/assets/4ad9cab4-b1c3-4c56-8547-80af22672ade" />

**Map image from 140,380 to 170,400 floor 6 with no lower floors:**
```lua
g_map.saveImage('test_map_6.png', 140, 380, 170, 400, 6, false)
```
<img width="960" height="640" alt="test_map_6" src="https://github.com/user-attachments/assets/a8bc2e88-76f2-4974-9734-aec2acc2db29" />

**Map image from 140,380 to 170,400 floor 6 with lower floors - default 'shadow' for lower floors is 0%:**
```lua
g_map.saveImage('test_map_6_lower.png', 140, 380, 170, 400, 6, true)
```
<img width="960" height="640" alt="test_map_6_lower" src="https://github.com/user-attachments/assets/1319efac-7112-4874-b432-4ea5f11efcf2" />

**Map image from 140,380 to 170,400 floor 6 with lower floors with 'shadow' for lower floors 60%:**
```lua
g_map.setLowerFloorsShadowPercent(60)
g_map.saveImage('test_map_6_lower_shadow_60.png', 140, 380, 170, 400, 6, true)
```
<img width="960" height="640" alt="test_map_6_lower_shadow_60" src="https://github.com/user-attachments/assets/efaeb485-e159-4655-90b7-0b9561f0f7ab" />


`Image` class limits maximum image size to ~2 GB, which with 4 bytes per pixel gives around 500kk pixels.
You cannot generate 32.000 x 32.000 minimap, but you can easily generate 16.000 x 16.000, so if you are generating RL map minimap, set start position to some high value, not 0 ex. `g_minimap.saveImage('test_minimap.png', 24000, 24000, 40000, 40000, 7)`.