### PR TITLE
fix: crash/error on client exit with proxy enabled

### DIFF
--- a/src/framework/core/application.cpp
+++ b/src/framework/core/application.cpp
@@ -116,6 +116,13 @@ void Application::deinit()
     g_modules.unloadModules();
     g_modules.clear();
 
+    // terminate proxy before garbage collection to ensure
+    // Protocol objects are properly released
+    g_proxy.terminate();
+
+    // poll remaining events after proxy termination
+    poll();
+
     // release remaining lua object references
     g_lua.collectGarbage();
 
@@ -139,9 +146,6 @@ void Application::terminate()
 
     // terminate script environment
     g_lua.terminate();
-
-    // terminate proxy
-    g_proxy.terminate();
 
     m_terminated = true;
 

--- a/src/framework/net/protocol.cpp
+++ b/src/framework/net/protocol.cpp
@@ -84,7 +84,10 @@ void Protocol::disconnect()
         return;
     }
     if (m_proxy) {
-        g_proxy.removeSession(m_proxy);
+        if (g_proxy.isWorking()) {
+            g_proxy.removeSession(m_proxy);
+        }
+        m_proxy = 0;
         return;
     }
     if (m_connection) {

--- a/src/framework/proxy/proxy.cpp
+++ b/src/framework/proxy/proxy.cpp
@@ -123,6 +123,8 @@ void ProxyManager::removeExtendedProxy(const std::string& host, uint16_t port, u
 
 void ProxyManager::removeSession(uint32_t sessionId)
 {
+    if (!m_working)
+        return;
     for (auto it = m_sessions.begin(); it != m_sessions.end(); ) {
         if (auto session = it->lock()) {
             if (session->getId() == sessionId) {

--- a/src/framework/proxy/proxy.h
+++ b/src/framework/proxy/proxy.h
@@ -18,6 +18,7 @@ public:
             m_maxActiveProxies = 1;
     }
     bool isActive();
+    bool isWorking() { return m_working; }
     void addProxy(const std::string& host, uint16_t port, int priority);
     void addExtendedProxy(const std::string& host, uint16_t port, uint16_t destinationPort, int priority);
     void removeProxy(const std::string& host, uint16_t port);


### PR DESCRIPTION
Probably nobody noticed it, but if you run OTCv8, connect to OTS using OTCv8 proxy and close client with Windows 'X' (close window of app) and click 'Force Exit', app crashes, as it removes/terminates `g_proxy` in wrong order. I noticed it running OTCv8 in VS debugger.

If you compile OTCv8 in 'Debug' mode, it shows error like this, when you press 'Force Exit' connected to OTS with OTCv8 proxy:
<img width="409" height="172" alt="image" src="https://github.com/user-attachments/assets/e4d291fd-28bc-47fe-9735-0250e98ac26e" />
as it cleans `g_proxy` shared pointers after terminating Lua - something like that, I did not analyse it, just AI summary of problem.

**Fix made using Claude Opus 4.5 (Thinking) in Antigravity**

I tested it in all scenarios with and without proxy. Now it always closes with no crash and no error.

**Only scenario I did not test:** connect to characters list and receive new list of proxies using `onProxyList` (`LoginServerProxyList`).

**EDIT:**
Little update after merge. Someone reported me this problem with screenshots. It generated Windows dumps on his PC:
<img width="735" height="56" alt="image" src="https://github.com/user-attachments/assets/e4ddf454-7a08-4552-97aa-f25d6f9e8333" />
