### PR TITLE
vBot support "Mage" vocation

### DIFF
--- a/modules/game_bot/default_configs/vBot_4.8/vBot/extras.lua
+++ b/modules/game_bot/default_configs/vBot_4.8/vBot/extras.lua
@@ -570,13 +570,14 @@ if true then
           guild = guild.."..."
         end
         local voc
-        if text:lower():find("sorcerer") then
+        local lowerText = text:lower()
+        if lowerText:find("sorcerer") or lowerText:find("mage") then
             voc = "MS"
-        elseif text:lower():find("druid") then
+        elseif lowerText:find("druid") then
             voc = "ED"
-        elseif text:lower():find("knight") then
+        elseif lowerText:find("knight") then
             voc = "EK"
-        elseif text:lower():find("paladin") then
+        elseif lowerText:find("paladin") then
             voc = "RP"
         end
         local creature = getCreatureByName(name)


### PR DESCRIPTION
several OT servers merge MS/ED vocation into a Mage vocation having the best features of both MS and ED.

Without this fix, on those servers, vBot would constantly error out with `Error: (...) concatenat voc: a nil value`

I tried submitting this upstream, but it seems vBot upstream is unmaintained: https://github.com/Vithrax/vBot/pull/17