### PR TITLE
Expose Directions to bot sandbox

### DIFF
--- a/modules/game_bot/executor.lua
+++ b/modules/game_bot/executor.lua
@@ -138,6 +138,7 @@ function executeBot(config, storage, tabs, msgCallback, saveConfigCallback, relo
   context.HTTP = HTTP
   context.OutputMessage = OutputMessage
   context.modules = modules
+  context.Directions = Directions
 
   -- log functions
   context.info = function(text) return msgCallback("info", tostring(text)) end


### PR DESCRIPTION
Allow doing
```lua
g_game.walk(Directions.South)
```
instead of
```lua
g_game.walk(2) -- 2 is the magic number for South
```
in cavebot waypoint Functions.