### PR TITLE
vBot item list scroll to bottom on new entry

### DIFF
--- a/modules/game_bot/functions/ui_elements.lua
+++ b/modules/game_bot/functions/ui_elements.lua
@@ -26,6 +26,13 @@ UI.Container = function(callback, unique, parent, widget)
   
   local oldItems = {}
   
+  local scrollToBottom = function()
+    local scrollbar = widget.scroll
+    if scrollbar and scrollbar.setValue and scrollbar.getMaximum then
+      scrollbar:setValue(scrollbar:getMaximum())
+    end
+  end
+
   local updateItems = function()
     local items = widget:getItems()
 
@@ -72,6 +79,7 @@ UI.Container = function(callback, unique, parent, widget)
     for i, child in ipairs(widget.items:getChildren()) do
       child.onItemChange = updateItems
     end
+    scrollToBottom()
   end
   
   widget.getItems = function()


### PR DESCRIPTION
previously when adding a new item to a large list, the list would scroll to the top each time.
For very long lists with a lot of stuff to add,
 this becomes increasingly annoying and time-consuming for each new entry.
If PR https://github.com/OTAcademy/otclientv8/pull/78 is accepted, large item lists are likely to become a lot more common (one entry for every garbage thing you do not want, allowing you to loot all the super-rare items you do not have the id for, or don't even know exist)
<img width="184" height="147" alt="image" src="https://github.com/user-attachments/assets/d28f1a41-b428-4c06-98cf-b084f00c669e" />
