### PR TITLE
vBot remove upstream version check

### DIFF
--- a/modules/game_bot/default_configs/vBot_4.8/vBot/main.lua
+++ b/modules/game_bot/default_configs/vBot_4.8/vBot/main.lua
@@ -1,40 +1,4 @@
 local version = "4.8"
-local currentVersion
-local available = false
-
-storage.checkVersion = storage.checkVersion or 0
-
--- check max once per 12hours
-if os.time() > storage.checkVersion + (12 * 60 * 60) then
-
-    storage.checkVersion = os.time()
-    
-    HTTP.get("https://raw.githubusercontent.com/Vithrax/vBot/main/vBot/version.txt", function(data, err)
-        if err then
-          warn("[vBot updater]: Unable to check version:\n" .. err)
-          return
-        end
-
-        currentVersion = data
-        available = true
-    end)
-
-end
-
 UI.Label("vBot v".. version .." \n Vithrax#5814")
 UI.Button("Official OTCv8 Discord!", function() g_platform.openUrl("https://discord.gg/yhqBE4A") end)
 UI.Separator()
-
-schedule(5000, function()
-
-    if not available then return end
-    if currentVersion ~= version then
-        
-        UI.Separator()
-        UI.Label("New vBot is available for download! v"..currentVersion)
-        UI.Button("Go to vBot GitHub Page", function() g_platform.openUrl("https://github.com/Vithrax/vBot") end)
-        UI.Separator()
-        
-    end
-
-end)


### PR DESCRIPTION
vBot upstream has been abandoned, last commit was in 2022, PR's are being ignored (for example https://github.com/Vithrax/vBot/pull/18 has been ignored since 2024)

and the check may cause sporadic network failures:

```
WARNING: [BOT] [vBot updater]: Unable to check version:
HttpSession timeout after 2 seconds
ERROR: TCP connection failed: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
ERROR: HttpSession unable to connect https://raw.githubusercontent.com/Vithrax/vBot/main/vBot/version.txt: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
```