### PR TITLE
fix vBot looting distance

### DIFF
--- a/modules/game_bot/default_configs/cavebot_1.3/targetbot/looting.lua
+++ b/modules/game_bot/default_configs/cavebot_1.3/targetbot/looting.lua
@@ -138,9 +138,9 @@ TargetBot.Looting.process = function(targets, dangerLevel)
   end
 
   local tile = g_map.getTile(loot.pos)
-  if dist >= 3 or not tile then
+  if dist > 1 or not tile then
     loot.tries = loot.tries + 1
-    TargetBot.walkTo(loot.pos, 20, { ignoreNonPathable = true, precision = 2 })
+    TargetBot.walkTo(loot.pos, 20, { ignoreNonPathable = true, precision = 1 })
     return true
   end
 

--- a/modules/game_bot/default_configs/vBot_4.8/targetbot/looting.lua
+++ b/modules/game_bot/default_configs/vBot_4.8/targetbot/looting.lua
@@ -148,9 +148,9 @@ TargetBot.Looting.process = function(targets, dangerLevel)
   end
 
   local tile = g_map.getTile(loot.pos)
-  if dist >= 3 or not tile then
+  if dist > 1 or not tile then
     loot.tries = loot.tries + 1
-    TargetBot.walkTo(loot.pos, 20, { ignoreNonPathable = true, precision = 2 })
+    TargetBot.walkTo(loot.pos, 20, { ignoreNonPathable = true, precision = 1 })
     return true
   end
 


### PR DESCRIPTION
vBot would sometimes try to loot from 2 squares away, and get stuck with "too far away" errors.
<img width="460" height="532" alt="image" src="https://github.com/user-attachments/assets/661671b4-7dbf-4ec3-b421-e26acbcf1f70" />
