### PR TITLE
findItem api search ammo slot

### DIFF
--- a/modules/game_bot/functions/player.lua
+++ b/modules/game_bot/functions/player.lua
@@ -149,11 +149,7 @@ context.findItem = function(itemId, subType)
   if subType == nil then
     subType = -1
   end
-  local ammo = context.player:getInventoryItem(InventorySlotAmmo)
-  if ammo and ammo:getId() == itemId and (subType == -1 or ammo:getSubType() == subType) then
-    return ammo
-  end
-  return g_game.findItemInContainers(itemId, subType)
+  return g_game.findPlayerItem(itemId, subType)
 end
 
 context.attack = g_game.attack


### PR DESCRIPTION
previously, if you had a rope in the ammo slot, the findItem api would miss it.

resolve https://github.com/OTAcademy/otclientv8/issues/85