### PR TITLE
fix multiclient minimap corruption

### DIFF
--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -20,9 +20,12 @@
  * THE SOFTWARE.
  */
 
-#ifndef WIN32
+#ifdef WIN32
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <sys/file.h>
+#include <unistd.h>
 #endif
 #include "minimap.h"
 #include "tile.h"


### PR DESCRIPTION
minimap could get corrupted if multiple clients tried reading/writing otmm concurrently.
fix with filelocking.

resolves https://github.com/OTAcademy/otclientv8/pull/21

I can imagine an even better fix than this, by having the otclients use a minimap merge strategy, instead of saveOtmm ignoring the minimap on disk at the same of save, it could load the existing minimap and merge in it's own newly gained knowledge, but that would be significantly more complex, I don't have time for that.