### PR TITLE
Increase cavebot_1.3 lure count max to 30

### DIFF
--- a/modules/game_bot/default_configs/cavebot_1.3/targetbot/creature_editor.lua
+++ b/modules/game_bot/default_configs/cavebot_1.3/targetbot/creature_editor.lua
@@ -80,7 +80,7 @@ TargetBot.Creature.edit = function(config, callback) -- callback = function(newC
   addScrollBar("danger", "Danger", 0, 10, 1)
   addScrollBar("maxDistance", "Max distance", 1, 10, 10)
   addScrollBar("keepDistanceRange", "Keep distance", 1, 5, 1)
-  addScrollBar("lureCount", "Lure", 0, 5, 1)
+  addScrollBar("lureCount", "Lure", 0, 30, 1)
 
   addScrollBar("minMana", "Min. mana for attack spell", 0, 3000, 200)
   addScrollBar("attackSpellDelay", "Attack spell delay", 200, 5000, 2500)

--- a/modules/game_bot/default_configs/cavebot_1.3/targetbot_configs/config_name.json
+++ b/modules/game_bot/default_configs/cavebot_1.3/targetbot_configs/config_name.json
@@ -30,7 +30,7 @@
       "groupAttackIgnorePlayers": true,
       "maxDistance": 10,
       "groupAttackIgnoreParty": false,
-      "lureCount": 5,
+      "lureCount": 30,
       "useGroupAttack": false,
       "groupRuneAttackTargets": 2,
       "attackSpell": "",


### PR DESCRIPTION
- sometimes luring more than 5 is beneficial.
- there is no obvious architectural reason for the existing max-5-limit.
- vBot already support up to 30

<img width="1899" height="1228" alt="image" src="https://github.com/user-attachments/assets/d2208ff4-75f4-42bd-a32f-ee16f6c5940d" />
